### PR TITLE
fix: remove double execute() in HTTP interceptor chain causing media uploads to fail

### DIFF
--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/di/AppComponent.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/di/AppComponent.kt
@@ -47,6 +47,8 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.plugins.plugin
+import io.ktor.http.Url
+import io.ktor.http.set
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import me.tatarka.inject.annotations.Component
@@ -124,8 +126,17 @@ abstract class AppComponent(
             }
         }.apply {
             plugin(HttpSend).intercept { request ->
-                with(session) { intercept(request) }
-                with(authInterceptor) {intercept(request)}
+                // Apply the correct server URL from session credentials without executing.
+                // Previously Session.intercept() called execute() here, which caused every
+                // request to be sent twice: once without the Bearer token (triggering a 401
+                // from the server) and once with it. For multipart uploads the first execute
+                // consumes the request body, so the retried authenticated request fails too.
+                session.credentials.value?.let { creds ->
+                    if (request.url.host != "api.fedisea.surf" && request.url.host != "pixelfed.org") {
+                        request.url.set(host = Url(creds.serverUrl).host)
+                    }
+                }
+                with(authInterceptor) { intercept(request) }
             }
         }
     }

--- a/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/domain/service/session/Session.kt
+++ b/sharedUI/src/commonMain/kotlin/com/daniebeler/pfpixelix/domain/service/session/Session.kt
@@ -1,17 +1,9 @@
 package com.daniebeler.pfpixelix.domain.service.session
 
 import com.daniebeler.pfpixelix.di.AppSingleton
-import io.ktor.client.call.HttpClientCall
-import io.ktor.client.plugins.Sender
-import io.ktor.client.request.HttpRequestBuilder
-import io.ktor.http.Url
-import io.ktor.http.set
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.map
 import me.tatarka.inject.annotations.Inject
 
 @Inject
@@ -22,17 +14,5 @@ class Session {
 
     fun setCredentials(credentials: Credentials?) {
         credentialsState.value = credentials
-    }
-
-    suspend fun Sender.intercept(request: HttpRequestBuilder): HttpClientCall {
-        credentials.value?.let { creds ->
-            request.apply {
-                if (url.host != "api.fedisea.surf" && url.host != "pixelfed.org") {
-                    url.set(host = Url(creds.serverUrl).host)
-                   // headers["Authorization"] = "Bearer ${creds.token}"
-                }
-            }
-        }
-        return execute(request)
     }
 }


### PR DESCRIPTION
## Summary

Media uploads (`POST /api/v2/media`) fail intermittently — especially when uploading multiple files at once. Single uploads sometimes succeed, mass uploads almost always fail.

### Root Cause

The `HttpSend` interceptor in `AppComponent` calls `execute(request)` **twice** per request:

```kotlin
// BEFORE (broken)
plugin(HttpSend).intercept { request ->
    with(session) { intercept(request) }        // execute() #1 — NO Bearer token
    with(authInterceptor) { intercept(request) } // execute() #2 — with Bearer token
}
```

`Session.intercept()` sets the server URL host and then calls `execute(request)`, which **sends the actual network request without the Authorization header**. The server receives an unauthenticated request and returns `401`/`500`. Because `expectSuccess = true` is configured on the `HttpClient`, ktor throws a `ServerResponseException` on the 500 response — so `AuthInterceptor.intercept()` on the next line is **never reached**.

For multipart uploads in particular, even in cases where the exception doesn't propagate, the first `execute()` call consumes the streaming request body. The second `execute()` in `AuthInterceptor` then sends an empty body to the server, which rejects it.

I was able to confirm this by adding request-level logging on the server side. Every failed upload arrived with `Authorization: (missing)`. The few that eventually succeeded arrived with `Authorization: Bearer <token>` — sent by `AuthInterceptor` in the rare cases where the first execute did not throw.

### Fix

Inline the URL-host substitution from `Session` directly into the `HttpSend` interceptor block, **without calling `execute()`**. Then delegate to `AuthInterceptor.intercept()` which adds the Bearer token and performs a single `execute()`:

```kotlin
// AFTER (fixed)
plugin(HttpSend).intercept { request ->
    session.credentials.value?.let { creds ->
        if (request.url.host != "api.fedisea.surf" && request.url.host != "pixelfed.org") {
            request.url.set(host = Url(creds.serverUrl).host)
        }
    }
    with(authInterceptor) { intercept(request) }
}
```

`Session.intercept()` (the member extension on `Sender`) is no longer needed and is removed along with its now-unused imports.

## Test plan

- [ ] Single photo upload succeeds
- [ ] Single video upload succeeds
- [ ] Mass upload (multiple photos + videos selected at once) succeeds without any 401/500 errors
- [ ] Token refresh flow still works (expired token → refresh → retry)
- [ ] Login / logout unaffected